### PR TITLE
[Fea/#21] 맞팔, 비맞팔 상태 저장

### DIFF
--- a/src/apis/users/getUser.ts
+++ b/src/apis/users/getUser.ts
@@ -1,13 +1,43 @@
+import { User } from '@typings/users/usersType';
 import instance from '../index';
 
 export const getUser = async (token: string) => {
   try {
-    const response = await instance.get(`/user`, {
+    const userResponse = await instance.get(`/user`, {
       headers: {
         Authorization: `Bearer ${token}`,
       },
     });
-    return response.data;
+
+    const username = userResponse.data.login;
+
+    const [followersResponse, followingResponse] = await Promise.all([
+      instance.get(`/users/${username}/followers`, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      }),
+      instance.get(`/users/${username}/following`, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      }),
+    ]);
+
+    const followingSet = new Set(followingResponse.data.map((user: User) => user.login));
+
+    const followForFollow = followersResponse.data.filter((user: User) =>
+      followingSet.has(user.login)
+    );
+    const nonFollowForFollow = followersResponse.data.filter(
+      (user: User) => !followingSet.has(user.login)
+    );
+
+    return {
+      ...userResponse.data,
+      followForFollow,
+      nonFollowForFollow,
+    };
   } catch (error) {
     console.error('Error fetching user data:', error);
     throw error;

--- a/src/hooks/users/useFetchUser.ts
+++ b/src/hooks/users/useFetchUser.ts
@@ -1,16 +1,19 @@
 import { useMutation, useQueryClient } from 'react-query';
 import { getUser } from '@apis/users/getUser';
 import { useUserStore } from '@hooks/users/useUserStore';
-import { User } from '@typings/users/usersType';
 
 export const useFetchUser = () => {
   const setUser = useUserStore((state) => state.setUser);
+  const setFollowForFollow = useUserStore((state) => state.setFollowForFollow);
+  const setNonFollowForFollow = useUserStore((state) => state.setNonFollowForFollow);
   const queryClient = useQueryClient();
 
   const mutation = useMutation({
     mutationFn: (token: string) => getUser(token),
-    onSuccess: (data: User) => {
+    onSuccess: (data) => {
       setUser(data);
+      setFollowForFollow(data.followForFollow);
+      setNonFollowForFollow(data.nonFollowForFollow);
       queryClient.invalidateQueries({ queryKey: ['user'] });
     },
     onError: (error) => {

--- a/src/hooks/users/useUserStore.ts
+++ b/src/hooks/users/useUserStore.ts
@@ -3,5 +3,9 @@ import { create } from 'zustand';
 
 export const useUserStore = create<UserState>((set) => ({
   user: null,
+  followForFollow: [],
+  nonFollowForFollow: [],
   setUser: (user) => set({ user }),
+  setFollowForFollow: (followForFollow) => set({ followForFollow }),
+  setNonFollowForFollow: (nonFollowForFollow) => set({ nonFollowForFollow }),
 }));

--- a/src/typings/users/usersType.ts
+++ b/src/typings/users/usersType.ts
@@ -35,5 +35,9 @@ export interface User {
 
 export interface UserState {
   user: User | null;
+  followForFollow: User[];
+  nonFollowForFollow: User[];
   setUser: (user: User) => void;
+  setFollowForFollow: (followers: User[]) => void;
+  setNonFollowForFollow: (followers: User[]) => void;
 }


### PR DESCRIPTION
<!-- PR의 제목은 "[Feat/#1] 로그인 기능 추가" 와 같이 작성해주세요! -->

## 📌 관련 이슈번호

<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

- Closes #21 

## ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. 팔로잉 팔로워 정보 가져오기
2. 맞팔, 비맞팔 상태 저장

## 📢 To Reviewers

- 유저 상태에 user(유저 기본 정보, 팔로워 수, 팔로잉 수 등), followForFollow(맞팔 객체들), nonFollowForFollow(맞팔 안한 객체들)을 저장했습니다.

```
  user: User | null;
  followForFollow: User[];
  nonFollowForFollow: User[];
```

## 📸 스크린샷

<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->
